### PR TITLE
Add (questionably) better landing page

### DIFF
--- a/modules/decal_common/files/lab6/itworks.html
+++ b/modules/decal_common/files/lab6/itworks.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>IT WORKS!!!!</title>
+    <style type="text/css">
+      body {
+        color: #00ff00;
+        overflow-x: hidden;
+      }
+
+      .giant {
+        font-size: 160pt;
+        font-weight: 900;
+      }
+
+      .blink {
+        animation: blink 2s steps(2, start) infinite;
+      }
+
+      @keyframes blink {
+        to { visibility: hidden; }
+      }
+
+      .marquee {
+        display: inline-block;
+        position: relative;
+        animation: marquee 10s linear infinite;
+      }
+
+      @keyframes marquee {
+        from { left: 100%; }
+        to { left: -70%; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="marquee"><span class="giant blink">IT WORKS</span></div>
+  </body>
+</html>

--- a/modules/decal_common/manifests/broken_apache.pp
+++ b/modules/decal_common/manifests/broken_apache.pp
@@ -4,6 +4,10 @@
 class decal_common::broken_apache {
   package { 'apache2':; } ->
   file {
+    '/var/www/html/index.html':
+      source => 'puppet:///modules/decal_common/lab6/itworks.html',
+  } ->
+  file {
     '/opt/lab6':
       source  => 'puppet:///modules/decal_common/lab6',
       recurse => true;


### PR DESCRIPTION
My original plan was for the student to see the Nginx landing
page upon installing and starting Nginx. But that doesn't work
because the page is suppressed by Apache's landing page.
Let's just use our own landing page instead.